### PR TITLE
updates base64 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "hsivonen/charset" }
 
 [dependencies]
 encoding_rs = "0.8.22"
-base64 = "0.11.0"
+base64 = "0.13"
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
See also https://github.com/staktrace/mailparse/pull/71, all tests passed locally. 

There is no reason other than to minimize the dependency tree and to get rid of the following issues:

```console
$ cargo doc
warning: output filename collision.
The lib target `base64` in package `base64 v0.12.2` has the same output filename as the lib target `base64` in package `base64 v0.10.1`.
Colliding filename is: /home/user/projects/mail/target/doc/base64/index.html

$ cargo clippy
warning: multiple versions for dependency `base64`: 0.10.1, 0.11.0, 0.12.2
```

A release after merge would be appreciated to also get this change into the `mailparse` crate. I don't know what the impact of the other changes since the last release are. In case those changes aren't ready to be released yet, feel free to let me know onto which commit I should rebase. 